### PR TITLE
Bump `tonic` and `prost`, and disable default features for `tonic`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["gRPC", "tonic", "error"]
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 thiserror = "1.0"
-tonic = "0.7"
+tonic = "0.11"
 tonic-error-impl = {version = "0.3.0", path = "tonic-error-impl" }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["gRPC", "tonic", "error"]
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 thiserror = "1.0"
-tonic = "0.11"
+tonic = { version = "0.11", default-features = false }
 tonic-error-impl = {version = "0.3.0", path = "tonic-error-impl" }
 
 [workspace]

--- a/tonic-error-example/Cargo.toml
+++ b/tonic-error-example/Cargo.toml
@@ -8,16 +8,16 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-prost = "0.10"
+prost = "0.12"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 thiserror = "1.0"
-tonic = "0.7"
+tonic = "0.11"
 tonic-error = {version = "0.3.0", path = ".." }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-tonic-build = "0.7"
+tonic-build = "0.11"
 
 [[bin]]
 name = "client"

--- a/tonic-error-impl/Cargo.toml
+++ b/tonic-error-impl/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.20"
-syn = "2.0"
+syn = "1.0.98"

--- a/tonic-error-impl/Cargo.toml
+++ b/tonic-error-impl/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.20"
-syn = "1.0.98"
+syn = "2.0"


### PR DESCRIPTION
The default features for `tonic` make compilation for WASM targets impossible, and disabling these features appears to have no detrimental effect on the crate. 